### PR TITLE
Edge hiding fixes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -27,10 +27,10 @@ function showOnlyEdges(canvas: any, idsToShow?: Set<string>) {
 	for (const edge of edges) {
 		if (idsToShow === undefined || idsToShow.has(edge.id)) {
 			edge.lineGroupEl.style.display = "";
-			edge.markerGroupEl.style.display = "";
+			edge.lineEndGroupEl.style.display = "";
 		} else {
 			edge.lineGroupEl.style.display = "none";
-			edge.markerGroupEl.style.display = "none";
+			edge.lineEndGroupEl.style.display = "none";
 		}
 	}
 }
@@ -197,7 +197,7 @@ export default class CanvasFilterPlugin extends Plugin {
 					const edge = canvas.edges.get(selected.id);
 					if (edge) {
 						edge.lineGroupEl.style.display = "none";
-						edge.markerGroupEl.style.display = "none";
+						edge.lineEndGroupEl.style.display = "none";
 					}
 				}
 

--- a/main.ts
+++ b/main.ts
@@ -206,6 +206,40 @@ export default class CanvasFilterPlugin extends Plugin {
 		});
 
 		this.addCommand({
+			id: 'show-hide-connected',
+			name: 'selected with connections HIDE',
+			checkCallback: this.ifActiveViewIsCanvas((canvas, canvasData) => {
+
+				const selection: any = Array.from(canvas.selection);
+				if (selection.length === 0) {
+					new Notice("Please select at least one node");
+					return;
+				}
+
+				for (const selected of selection) {
+					const node = canvas.nodes.get(selected.id);
+					if (node) {
+						node.nodeEl.hide();
+						const connections = canvasData.edges.filter(x => x.fromNode === node.id || x.toNode === node.id); 
+						for (const connection of connections) {
+							const edge = canvas.edges.get(connection.id);
+							edge.lineGroupEl.style.display = "none";
+							edge.lineEndGroupEl.style.display = "none";
+						}
+					}
+					
+					const edge = canvas.edges.get(selected.id);
+					if (edge) {
+						edge.lineGroupEl.style.display = "none";
+						edge.markerGroupEl.style.display = "none";
+					}
+				}
+
+				canvas.deselectAll();
+			})
+		});
+
+		this.addCommand({
 			id: 'show-connected-nodes-from-to',
 			name: 'show with ARROWS TO/FROM',
 			checkCallback: this.ifActiveViewIsCanvas((canvas, canvasData) => {


### PR DESCRIPTION
Fix #6, by fixing the wrong attribute name (`markerGroupEl` instead of `lineEndGroupEl`).
Fix #7, by adding additional command that hides selected nodes and their incoming and outgoing edes.

The second one is a bit wonky - currently Obsidian does not select edges when doing a drag selection. Therefore, they don't get hidden. To preserve existing functionality I added a second command that iterates over associated edges.